### PR TITLE
Refactor speech recognizer for multiple locales

### DIFF
--- a/myBiography/ContentView.swift
+++ b/myBiography/ContentView.swift
@@ -13,6 +13,13 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 20) {
+            Picker("Language", selection: $speechRecognizer.currentLocale) {
+                ForEach(speechRecognizer.supportedLocales, id: \.self) { locale in
+                    Text(locale.identifier).tag(locale)
+                }
+            }
+            .pickerStyle(.segmented)
+
             Text(speechRecognizer.recognizedText)
                 .padding()
                 .frame(maxHeight: 200)


### PR DESCRIPTION
## Summary
- simplify `SpeechRecognizer` to hold a single `SFSpeechRecognizer`
- expose `currentLocale` and `supportedLocales`
- add segmented `Picker` in `ContentView` for choosing language
- cancel recognition task correctly when stopping

## Testing
- `swiftc myBiography/ContentView.swift myBiography/SpeechRecognizer.swift -parse`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6882f3ed48fc8324ab66c8c7aaa0940f