### PR TITLE
Fix unicode escape issue in Localization

### DIFF
--- a/myBiography/Localization.swift
+++ b/myBiography/Localization.swift
@@ -12,22 +12,22 @@ struct Localization {
             "listening": "(Listening...)"
         ],
         "zh": [
-            "language": "\u8bed\u8a00",
-            "start_recording": "\u5f00\u59cb\u5f55\u97f3",
-            "stop_recording": "\u7ed3\u675f\u5f55\u97f3",
-            "recording_unavailable": "\u65e0\u6cd5\u5f55\u97f3\u3002",
-            "speech_authorization_denied": "\u8bed\u97f3\u8bc6\u522b\u6743\u9650\u88ab\u62d2\u7edd\u3002",
-            "speech_not_available": "\u8bed\u97f3\u8bc6\u522b\u65e0\u6cd5\u4f7f\u7528\u3002",
-            "listening": "\uff08\u6b63\u5728\u542c...\uff09"
+            "language": "语言",
+            "start_recording": "开始录音",
+            "stop_recording": "结束录音",
+            "recording_unavailable": "无法录音。",
+            "speech_authorization_denied": "语音识别权限被拒绝。",
+            "speech_not_available": "语音识别无法使用。",
+            "listening": "（正在听...）"
         ],
         "ja": [
-            "language": "\u8a00\u8a9e",
-            "start_recording": "\u9332\u97f3\u958b\u59cb",
-            "stop_recording": "\u9332\u97f3\u505c\u6b62",
-            "recording_unavailable": "\u9332\u97f3\u3067\u304d\u307e\u305b\u3093\u3002",
-            "speech_authorization_denied": "\u97f3\u58f0\u8a8d\u8b58\u306e\u8a31\u53ef\u304c\u62d2\u5426\u3055\u308c\u307e\u3057\u305f\u3002",
-            "speech_not_available": "\u97f3\u58f0\u8a8d\u8b58\u306f\u5229\u7528\u3067\u304d\u307e\u305b\u3093\u3002",
-            "listening": "\uff08\u805e\u3044\u3066\u3044\u307e\u3059...\uff09"
+            "language": "言語",
+            "start_recording": "録音開始",
+            "stop_recording": "録音停止",
+            "recording_unavailable": "録音できません。",
+            "speech_authorization_denied": "音声認識の許可が拒否されました。",
+            "speech_not_available": "音声認識は利用できません。",
+            "listening": "（聞いています...）"
         ]
     ]
 


### PR DESCRIPTION
## Summary
- replace invalid unicode escape sequences with actual characters in `Localization.swift`

## Testing
- `swiftc -o /tmp/localization_test myBiography/Localization.swift`

------
https://chatgpt.com/codex/tasks/task_e_6886e4a7f5c4832484646f9c16b3f191